### PR TITLE
Avoid NPE when getting the system ID

### DIFF
--- a/src/info/histei/extensions/HTSchemaManagerFilter.java
+++ b/src/info/histei/extensions/HTSchemaManagerFilter.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import ro.sync.contentcompletion.xml.*;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 
@@ -16,24 +17,20 @@ import java.util.List;
  */
 public class HTSchemaManagerFilter implements SchemaManagerFilter {
 
-    private final URL editorLocation;
     private SchemaListProvider schemaListProvider;
 
-    public HTSchemaManagerFilter() {
-        editorLocation = OxygenUtils.getCurrentEditorLocation();
-    }
-
-    @NotNull
-    public URL getEditorLocation() {
-        return editorLocation;
-    }
-
     @Nullable
-    public SchemaListProvider getSchemaListProvider() {
-        if (schemaListProvider == null) {
-            schemaListProvider = SchemaListProvider.get(getEditorLocation());
+    public SchemaListProvider getSchemaListProvider(String systemID) {
+      if (schemaListProvider == null) {
+        try {
+          URL url = new URL(systemID);
+          schemaListProvider = SchemaListProvider.get(url);
+        } catch (MalformedURLException e) {
+          // Shouldn't happen. The system Id is obtained from Oxygen API.
+          e.printStackTrace();
         }
-        return schemaListProvider;
+      }
+      return schemaListProvider;
     }
 
     @Override
@@ -48,7 +45,7 @@ public class HTSchemaManagerFilter implements SchemaManagerFilter {
 
     @Override
     public List<CIValue> filterAttributeValues(List<CIValue> ciValues, WhatPossibleValuesHasAttributeContext context) {
-        SchemaListProvider provider = getSchemaListProvider();
+        SchemaListProvider provider = getSchemaListProvider(context.getSystemID());
 
         if (provider != null) {
             SchemaList<SchemaListItem> list = provider.getList(context);

--- a/src/info/histei/utils/OxygenUtils.java
+++ b/src/info/histei/utils/OxygenUtils.java
@@ -210,7 +210,12 @@ public final class OxygenUtils {
 
     @Nullable
     public static URL getCurrentEditorLocation() {
-        return PluginWorkspaceProvider.getPluginWorkspace().getCurrentEditorAccess(PluginWorkspace.MAIN_EDITING_AREA).getEditorLocation();
+    	URL editorLocation = null;
+        WSEditor currentEditorAccess = PluginWorkspaceProvider.getPluginWorkspace().getCurrentEditorAccess(PluginWorkspace.MAIN_EDITING_AREA);
+        if (currentEditorAccess != null) {
+        	editorLocation = currentEditorAccess.getEditorLocation();
+        }
+		return editorLocation;
     }
 
     @Nullable


### PR DESCRIPTION
A NPE reported by Oxygen users. 

There is an API that you can use to get the system ID of the editor involved in question instead of relying on the current selected editor.